### PR TITLE
fix: 补充决策为'不参与'时的日志

### DIFF
--- a/roles/front_desk.py
+++ b/roles/front_desk.py
@@ -436,7 +436,11 @@ class FrontDesk:
                         f"AngelHeart[{chat_id}]: 上游唤醒聊天事件未获批准，已停止后续主 LLM 处理。"
                     )
                     event.stop_event()
-                # 决策不需要回复，立即释放门锁（设置较短的“不回复”冷却）
+                # 决策不需要回复，记录原因并立即释放门锁（设置较短的“不回复”冷却）
+                if decision:
+                    logger.info(f"AngelHeart[{chat_id}]: 决策为'不参与'。原因: {decision.reply_strategy}")
+                else:
+                    logger.warning(f"AngelHeart[{chat_id}]: 分析失败，无决策结果")
                 no_reply_cd = self.context.config_manager.no_reply_cooldown
                 await self.context.release_chat_processing(chat_id, set_cooldown=True, duration=no_reply_cd)
             # 注意：需要回复的情况，门锁释放由 main.py 的 strip_markdown_on_decorating_result 方法统一处理


### PR DESCRIPTION
秘书分析结果为不参与时，缺少对应的log输出，使其表现为卡在LLM分析
[issues/40](https://github.com/kawayiYokami/astrbot_plugin_angel_heart/issues/40)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 增强了内部日志记录，在特定决策场景下提供更详细的诊断信息，便于系统监控和问题追踪。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kawayiYokami/astrbot_plugin_angel_heart/pull/42)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->