### PR TITLE
fix(core): 避免对指令类消息执行 Markdown 清洗以保留排版格式

### DIFF
--- a/main.py
+++ b/main.py
@@ -461,6 +461,12 @@ class AngelHeartPlugin(Star):
         """
         chat_id = event.unified_msg_origin
         try:
+            if self._is_upstream_command_event(event):
+                logger.debug(
+                    f"AngelHeart[{chat_id}]: 检测到是上游指令事件，跳过 Markdown 清洗。"
+                )
+                return
+
             logger.debug(f"AngelHeart[{chat_id}]: 开始清洗消息链中的Markdown格式...")
 
             # 从 event 对象中获取消息链


### PR DESCRIPTION
### 问题背景 (Problem)
目前插件在消息发送前注册了全局的 `on_decorating_result` 过滤器，用于将消息中的 Markdown 符号清洗为纯文本。

但由于该过滤器是全局拦截的，当用户触发**指令类回复**（例如 `/help`、插件状态面板、各种 `/debug` 诊断信息等）时，这些格式化文本中的列表前缀（`  - `）、代码块或特定的对齐排版也会被当作 Markdown 被一并清洗掉，导致指令输出排版错乱。

如果用户为了保留指令排版而直接在配置中关闭 `strip_markdown_enabled`，又会导致日常 LLM 对话中带有多余的 Markdown 标记（由于 QQ 客户端不支持 Markdown 渲染，这会影响普通对话的观感）。

### 解决方案 (Solution)
在 `strip_markdown_on_decorating_result` 执行清洗前，增加对事件类型的预检。如果是**上游指令事件**（即命中 `CommandFilter` 或 `CommandGroupFilter`）或被标记为指令回复的事件，则直接跳过清洗。

这样可以使得日常 AI 对话依然保持干净的 Markdown 清洗效果，而所有指令输出、对齐列表和诊断信息能够完美保留其原本的设计格式，无需用户手动关闭配置开关。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复在特定并发情况下工具装饰消息可能重复或丢失的情况，提升会话内消息发送的稳定性。

* **改进**
  * 优化工具调用的发送节流与顺序，减少重复发送并改善日志可追溯性。
  * 在消息清洗流程中增加更早的跳过判定并引入调试日志，避免对上游命令/技能事件执行不必要的处理，从而提升性能。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->