### PR TITLE
fix: pass plugin name to StarTools.get_data_dir() to avoid inspect.stack() crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ class AngelHeartPlugin(Star):
         self._whitelist_cache = self._prepare_whitelist()
 
         # -- 获取插件数据目录 --
-        plugin_data_dir = StarTools.get_data_dir()
+        plugin_data_dir = StarTools.get_data_dir("astrbot_plugin_angel_heart")
 
         # -- 创建 AngelHeartContext 全局上下文（包含 ConversationLedger）--
         self.angel_context = AngelHeartContext(self.config_manager, self.context, plugin_data_dir)


### PR DESCRIPTION
### Problem
When `StarTools.get_data_dir()` is called without arguments, the framework attempts to deduce the calling plugin name using `inspect.stack()`. Under certain environments (such as dynamic reloading, testing shims, or direct scripts where `__main__` is the entrypoint), metadata extraction fails, throwing a fatal `RuntimeError: 无法获取模块 __main__ 的元信息`.

### Solution
Explicitly pass the plugin name `"astrbot_plugin_angel_heart"` to the call of `StarTools.get_data_dir()` in `main.py` to avoid this dynamic inspection crash. This is safe, backwards-compatible, and robust across all execution environments.

### Validation
- Verified and tested successfully under AstrBot official environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 修复了并发场景下工具装饰消息出现重复或乱序发送的问题，增强并发处理的稳定性。
  * 优化了特定类型消息的处理逻辑，避免不必要的消息格式化操作。

* **改进**
  * 完善了插件数据管理机制：按插件名定位数据目录，减少数据冲突与混淆，提升可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### 💡 Ecosystem & Framework Context
This issue stems from a known vulnerability in the AstrBot core framework's path-resolving API. We have submitted a root-cause fix to the official AstrBot core repository: **[AstrBot Core PR #8588](https://github.com/AstrBotDevs/AstrBot/pull/8588)**.

However, this plugin-level change (passing the plugin name explicitly) remains **highly necessary** to ensure backward compatibility. It prevents the plugin from crashing on older installations of AstrBot that have not upgraded to the latest core version.

This is a safe, non-breaking, and recommended change.