### PR TITLE
fix: restore familiarity timeout config accessor

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -62,6 +62,10 @@ class ConfigManager:
     def observation_timeout(self) -> int:
         return self._get_grouped("timing", "observation_timeout", 60)
 
+    @property
+    def familiarity_timeout(self) -> int:
+        return self._get_grouped("timing", "familiarity_timeout", self.observation_timeout)
+
     # ========== leave_reply ==========
 
     @property


### PR DESCRIPTION
## Summary
- Add the missing ConfigManager.familiarity_timeout property used by front_desk timeout checks.
- Preserve compatibility with any existing timing.familiarity_timeout value.
- Fall back to observation_timeout when familiarity_timeout is absent, matching the current schema where familiarity_timeout is deprecated/hidden.

## Why
front_desk._check_and_handle_timeout reads config_manager.familiarity_timeout while handling GETTING_FAMILIAR state. Without this property, every timeout check raises AttributeError and can leave conversations in locked/detention states.

## Verification
- python3 -m py_compile core/config_manager.py roles/front_desk.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增熟悉度超时配置，可在 `timing` 配置分组中进行设置。
  * 未单独配置时，熟悉度超时将默认沿用观察超时设置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->